### PR TITLE
unit testing login and registration endpoints

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,9 +28,13 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r requirements.txt
 
+      - name: Set PYTHONPATH dynamically
+        run: echo "PYTHONPATH=${{ github.workspace }}:$PYTHONPATH" >> $GITHUB_ENV
+
       - name: Run unit tests
         env:
           AUTH_DATABASE_URL: "postgresql://auth_admin:dbpass@localhost/auth_db"
           JWT_SECRET: "supersecretkey"
           TOKEN_EXPIRE_MINS: "30"
         run: python -m unittest discover -s tests/unit_tests -p "test_*.py" -v
+

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,8 +33,8 @@ jobs:
 
       - name: Run unit tests
         env:
+          DATABASE_URL: "sqlite:///:memory:" 
           AUTH_DATABASE_URL: "postgresql://auth_admin:dbpass@localhost/auth_db"
           JWT_SECRET: "supersecretkey"
           TOKEN_EXPIRE_MINS: "30"
         run: python -m unittest discover -s tests/unit_tests -p "test_*.py" -v
-

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,11 @@ on:
 jobs:
   build:
     runs-on: ubuntu-22.04
+    env:
+      DATABASE_URL: "sqlite:///:memory:"   # Use in-memory SQLite for testing
+      AUTH_DATABASE_URL: "postgresql://auth_admin:dbpass@localhost/auth_db"
+      JWT_SECRET: "supersecretkey"
+      TOKEN_EXPIRE_MINS: "30"
     strategy:
       matrix:
         python-version: [3.7.13]
@@ -32,9 +37,4 @@ jobs:
         run: echo "PYTHONPATH=${{ github.workspace }}:$PYTHONPATH" >> $GITHUB_ENV
 
       - name: Run unit tests
-        env:
-          DATABASE_URL: "sqlite:///:memory:" 
-          AUTH_DATABASE_URL: "postgresql://auth_admin:dbpass@localhost/auth_db"
-          JWT_SECRET: "supersecretkey"
-          TOKEN_EXPIRE_MINS: "30"
         run: python -m unittest discover -s tests/unit_tests -p "test_*.py" -v

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,8 +10,7 @@ jobs:
   build:
     runs-on: ubuntu-22.04
     env:
-      DATABASE_URL: "sqlite:///:memory:"   # Use in-memory SQLite for testing
-      AUTH_DATABASE_URL: "postgresql://auth_admin:dbpass@localhost/auth_db"
+      AUTH_DATABASE_URL: "sqlite:///:memory:"   
       JWT_SECRET: "supersecretkey"
       TOKEN_EXPIRE_MINS: "30"
     strategy:

--- a/auth_service/db/database.py
+++ b/auth_service/db/database.py
@@ -1,7 +1,7 @@
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker, Session
-from config.settings import AUTH_DATABASE_URL
-from db.base import Base
+from auth_service.config.settings import AUTH_DATABASE_URL
+from auth_service.db.base import Base
 
 engine = create_engine(AUTH_DATABASE_URL)
 

--- a/auth_service/db/db_methods.py
+++ b/auth_service/db/db_methods.py
@@ -1,5 +1,5 @@
 from sqlalchemy.orm import Session
-from models.user import AuthUser
+from auth_service.models.user import AuthUser
 
 def get_user_by_email(db: Session, email: str):
     """

--- a/auth_service/main.py
+++ b/auth_service/main.py
@@ -15,8 +15,8 @@ Attributes:
 
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
-from db.database import engine, Base
-from routes import auth
+from auth_service.db.database import engine, Base
+from auth_service.routes import auth
 
 app = FastAPI()
 app.add_middleware(

--- a/auth_service/models/user.py
+++ b/auth_service/models/user.py
@@ -20,7 +20,7 @@ Classes:
                login data.
 """
 from sqlalchemy import Column, Integer, String
-from db.database import Base
+from auth_service.db.database import Base
 from pydantic import BaseModel
 
 class AuthUser(Base):

--- a/auth_service/routes/auth.py
+++ b/auth_service/routes/auth.py
@@ -1,10 +1,10 @@
 import uuid
 from fastapi import APIRouter, HTTPException, Depends
 from sqlalchemy.orm import Session
-from db.db_methods import get_user_by_email, create_user
-from db.database import get_db
-from utils.security import create_access_token, hash_password, verify_password
-from models.user import UserRegister, UserLogin
+from auth_service.db.db_methods import get_user_by_email, create_user
+from auth_service.db.database import get_db
+from auth_service.utils.security import create_access_token, hash_password, verify_password
+from auth_service.models.user import UserRegister, UserLogin
 
 router = APIRouter()
 
@@ -61,9 +61,14 @@ def login(user: UserLogin, db: Session = Depends(get_db)):
 
     Raises:
         HTTPException 400 (bad request): This gets raised if no user is found or if the password is invalid.
+
+        
     """
+
     auth_user = get_user_by_email(db, user.email)
+    print("🔍 Retrieved user:", vars(auth_user) if auth_user else "No user found")
     if not auth_user or not verify_password(user.password, auth_user.hashed_password):
+        print("❌ Login failed due to invalid credentials") 
         raise HTTPException(status_code=400, detail="Invalid username or password")
     token = create_access_token({"sub": auth_user.sub, "email": auth_user.email})
     return {"access_token": token, "token_type": "bearer"}

--- a/tests/unit_tests/test_auth_endpoints.py
+++ b/tests/unit_tests/test_auth_endpoints.py
@@ -5,7 +5,7 @@ This module tests the /register and /login endpoints defined in auth_service/rou
 """
 
 import os
-os.environ["DATABASE_URL"] = "sqlite:///:memory:"  # Force in-memory SQLite for testing
+os.environ["DATABASE_URL"] = "sqlite:///:memory:" 
 
 
 import uuid

--- a/tests/unit_tests/test_auth_endpoints.py
+++ b/tests/unit_tests/test_auth_endpoints.py
@@ -1,0 +1,130 @@
+"""
+Unit Test Suite for Auth Service API Endpoints
+
+This module tests the /register and /login endpoints defined in auth_service/routes/auth.py.
+"""
+
+import uuid
+import unittest
+from unittest.mock import MagicMock, patch
+from fastapi.testclient import TestClient
+
+
+from auth_service.main import app
+
+client = TestClient(app)
+
+class TestAuthEndpoints(unittest.TestCase):
+    """
+    Tests for the /register and /login endpoints.
+    """
+
+    def setUp(self):
+        """
+        Overrides the get_db dependency to supply a dummy database session.
+        """
+        self.dummy_db = MagicMock()
+        app.dependency_overrides = {
+            'get_db': lambda: iter([self.dummy_db])
+        }
+
+    def tearDown(self):
+        """
+        Removes dependency overrides.
+        """
+        app.dependency_overrides = {}
+
+    @patch("auth_service.routes.auth.get_user_by_email")
+    @patch("auth_service.routes.auth.create_user")
+    def test_register_new_user(self, mock_create_user, mock_get_user_by_email):
+        """
+        Confirming new user registration returns a valid JWT when the email is not used.
+        """
+        mock_get_user_by_email.return_value = None  
+        fake_sub = str(uuid.uuid4())
+        class FakeUser:
+            def __init__(self):
+                self.sub = fake_sub
+                self.email = "synx@ttesting.com"
+        fake_user = FakeUser()
+        mock_create_user.return_value = fake_user  
+        response = client.post("/register", json={"email": "synx@ttesting.com", "password": "testpass"})
+        self.assertEqual(response.status_code, 200, "Registration should succeed for a new user.")
+        data = response.json()
+        self.assertIn("access_token", data, "Response must include an access token.")
+        self.assertEqual(data.get("token_type"), "bearer", "Token type must be 'bearer'.")
+
+
+    @patch("auth_service.routes.auth.get_user_by_email")
+    def test_register_existing_user(self, mock_get_user_by_email):
+        """
+        Confirming registration fails when the email is already registered.
+        """
+        fake_user = object()
+        mock_get_user_by_email.return_value = fake_user
+        response = client.post("/register", json={"email": "synx@ttesting.com", "password": "testpass"})
+        self.assertEqual(response.status_code, 400, "Registration must fail for an existing user.")
+        data = response.json()
+        self.assertEqual(data.get("detail"), "That email is already registered",
+                        "Error message should indicate the email is already registered.")
+
+
+    @patch("auth_service.routes.auth.get_user_by_email")
+    def test_login_success(self, mock_get_user_by_email):
+        """
+        Confirming login returns a valid JWT for correct credentials.
+        """
+        plain_password = "testpass"
+        from auth_service.utils.security import hash_password
+        hashed = hash_password(plain_password)
+        class FakeUser:
+            def __init__(self):
+                self.sub = str(uuid.uuid4())
+                self.email = "synx@ttesting.com"
+                self.hashed_password = hashed
+        fake_user = FakeUser()
+        mock_get_user_by_email.return_value = fake_user  
+        response = client.post("/login", json={"email": "synx@ttesting.com", "password": plain_password})
+        self.assertEqual(response.status_code, 200, "Login should succeed for valid credentials.")
+        data = response.json()
+        self.assertIn("access_token", data, "Response must include an access token.")
+        self.assertEqual(data.get("token_type"), "bearer", "Token type must be 'bearer'.")
+
+    @patch("auth_service.routes.auth.get_user_by_email")
+    def test_login_failure_wrong_password(self, mock_get_user_by_email):
+        """
+        Confirming login fails with a 400 error for an incorrect password.
+        """
+        correct_password = "correctpass"
+        from auth_service.utils.security import hash_password  
+        hashed = hash_password(correct_password)
+        class FakeUser:
+            pass
+
+        fake_user = FakeUser()
+        fake_user.sub = str(uuid.uuid4())
+        fake_user.email = "synx@ttesting.com"
+        fake_user.hashed_password = hashed
+        mock_get_user_by_email.return_value = fake_user
+        response = client.post("/login", json={"email": "synx@ttesting.com", "password": "wrongpass"})
+        self.assertEqual(response.status_code, 400, "Login must fail for an incorrect password.")
+        data = response.json()
+        self.assertEqual(data.get("detail"), "Invalid username or password",
+                         "Error message should indicate invalid credentials.")
+
+    @patch("auth_service.routes.auth.get_user_by_email")
+    def test_login_failure_no_user(self, mock_get_user_by_email):
+        """
+        Confirming login fails with a 400 error when the email is not registered.
+        """
+        mock_get_user_by_email.return_value = None
+        response = client.post("/login", json={"email": "notarealthing@unreal.com", "password": "any"})
+        self.assertEqual(response.status_code, 400, "Login must fail for a non-existent user.")
+        data = response.json()
+        self.assertEqual(data.get("detail"), "Invalid username or password",
+                         "Error message should indicate invalid credentials.")
+
+
+if __name__ == "__main__":
+    unittest.main()
+

--- a/tests/unit_tests/test_auth_endpoints.py
+++ b/tests/unit_tests/test_auth_endpoints.py
@@ -4,10 +4,15 @@ Unit Test Suite for Auth Service API Endpoints
 This module tests the /register and /login endpoints defined in auth_service/routes/auth.py.
 """
 
+import os
+os.environ["DATABASE_URL"] = "sqlite:///:memory:"  # Force in-memory SQLite for testing
+
+
 import uuid
 import unittest
 from unittest.mock import MagicMock, patch
 from fastapi.testclient import TestClient
+
 
 
 from auth_service.main import app

--- a/tests/unit_tests/test_auth_utils.py
+++ b/tests/unit_tests/test_auth_utils.py
@@ -6,14 +6,11 @@ which include JWT token creation (with an expiration claim), password hashing,
 and password verification.
 """
 
-import os
-import sys
 import time
 import jwt
 import unittest
 
-# Add the inner "auth_service" directory to sys.path so that
-# the absolute import "from config.settings import ..." works.
+
 
 from auth_service.utils.security import create_access_token, hash_password, verify_password
 


### PR DESCRIPTION
Added a suite of unit tests for the Auth Service API endpoints by overriding the get_db dependency with a dummy database session using a MagicMock and patching key functions like get_user_by_email and create_user with unittest.mock.patch and an in-memory sql database     